### PR TITLE
#23 more elegant solution for clever dict.ignore

### DIFF
--- a/cleverdict/cleverdict.py
+++ b/cleverdict/cleverdict.py
@@ -411,7 +411,7 @@ class CleverDict(dict):
                 if isinstance(mapping, list):
                     mapping = {k: v for k, v in mapping if k in only}
             self.update(mapping, **kwargs)
-            if _aliases is not None and isinstance(_aliases, AliasesDict):
+            if _aliases is not None and isinstance(_aliases, (AliasesDict, dict)):
                 for k, v in _aliases.items():
                     self._add_alias(v, k)
             for k, v in _vars.items():
@@ -500,9 +500,9 @@ class CleverDict(dict):
 
     def check_if_unallowed_key(self, mapping=None, _aliases=None):
         contains_unallowed_key = False
-        if "_aliases" in mapping and not isinstance(mapping["_aliases"], AliasesDict):
+        if "_aliases" in mapping and not isinstance(mapping["_aliases"], (AliasesDict, dict)):
             contains_unallowed_key = True
-        if _aliases is not None and not isinstance(_aliases, AliasesDict):
+        if _aliases is not None and not isinstance(_aliases, (AliasesDict, dict)):
             contains_unallowed_key = True
         try:
             unallowed_pair = {obj[0]: obj[1] for obj in mapping if obj[0] == "_aliases"}

--- a/cleverdict/cleverdict.py
+++ b/cleverdict/cleverdict.py
@@ -3,6 +3,7 @@ import json
 import inspect
 import keyword
 import itertools
+from collections import UserDict
 from pathlib import Path
 from pprint import pprint
 from datetime import datetime
@@ -322,6 +323,10 @@ class Expand:
         CleverDict.expand = self.save_expand
 
 
+class AliasesDict(UserDict):
+    pass
+
+
 class CleverDict(dict):
     """
     A data structure which allows both object attributes and dictionary
@@ -379,7 +384,7 @@ class CleverDict(dict):
         **kwargs,
     ):
         ignore, only = _preprocess_options(ignore, exclude, only)
-        self.setattr_direct("_aliases", {})
+        self.setattr_direct("_aliases", AliasesDict())
         if isinstance(mapping, CleverDict):
             # for key, alias in mapping._aliases.items():
             #     if key != alias:
@@ -405,9 +410,11 @@ class CleverDict(dict):
                 if isinstance(mapping, list):
                     mapping = {k: v for k, v in mapping if k in only}
             self.update(mapping, **kwargs)
-            if _aliases is not None:
+            if _aliases is not None and isinstance(_aliases, AliasesDict):
                 for k, v in _aliases.items():
                     self._add_alias(v, k)
+            else:
+                raise RuntimeWarning("`_aliases` is an internal Attribute and can't be used")
             for k, v in _vars.items():
                 self.setattr_direct(k, v)
 

--- a/cleverdict/test_cleverdict.py
+++ b/cleverdict/test_cleverdict.py
@@ -281,7 +281,7 @@ class Test_Misc:
             x.to_list(exclude=[], ignore=[])
             x.to_list(exclude=[], ignore=[], only=[])
         x.to_list(
-            ignore=CleverDict.ignore, exclude=CleverDict.ignore, only=CleverDict.ignore
+            ignore=CleverDict.ignore_internals, exclude=CleverDict.ignore_internals, only=CleverDict.ignore_internals
         )
 
         x = CleverDict({0: "Zero", 1: "One"})
@@ -674,6 +674,32 @@ class Test_Misc:
         assert list(y.keys()) == ["name"]
         y = CleverDict(x, exclude="name")
         assert list(y.keys()) == ["nationality"]
+
+    def test_internal_save_was_overwritten(self):
+        x = CleverDict()
+        x['save'] = "What a great save!"
+        assert x['save'] == "What a great save!"
+        assert repr(x) == "CleverDict({'save': 'What a great save!'}, _aliases={}, _vars={})"
+
+    def test_internal_delete_was_overwritten(self):
+        x = CleverDict()
+        x['delete'] = "Jon Doe deleted XYZ"
+        assert x['delete'] == "Jon Doe deleted XYZ"
+        assert repr(x) == "CleverDict({'delete': 'Jon Doe deleted XYZ'}, _aliases={}, _vars={})"
+
+    def test_ignore_internal_save_explicit(self):
+        x = CleverDict()
+        x['save'] = "What a great save!"
+        assert x['save'] == "What a great save!"
+        assert x.__repr__(ignore=['save']) == "CleverDict({}, _aliases={}, _vars={})"
+
+    def test_ignore_internal_explicit(self):
+        x = CleverDict()
+        x['save'] = "What a great save!"
+        x['delete'] = "Jon Doe deleted XYZ"
+        assert x['save'] == "What a great save!"
+        assert x['delete'] == "Jon Doe deleted XYZ"
+        assert x.__repr__(ignore=['delete']) == "CleverDict({'save': 'What a great save!'}, _aliases={}, _vars={})"
 
 
 class Test_Internal_Logic:

--- a/cleverdict/test_cleverdict.py
+++ b/cleverdict/test_cleverdict.py
@@ -104,6 +104,20 @@ class Test_Initialisation:
         assert x._2 == "two"
         assert x._3 == "three"
 
+    def test_create_with_alias_as_key_name_is_not_possible_and_raises_a_runtime_warning(self):
+        data = {"total": 6, "usergroup": "Knights of Ni", "_aliases": ["Kn8 of Ni", 'Knights Who Say "Ni!"']}
+        with pytest.raises(RuntimeWarning):
+            CleverDict(data)
+
+        with pytest.raises(RuntimeWarning):
+             CleverDict(**data)
+
+        with pytest.raises(RuntimeWarning):
+            CleverDict(data.items())
+
+        with pytest.raises(RuntimeWarning):
+            CleverDict().fromkeys(["total", "usergroup", "_aliases"], "val")
+
 
 class Test_Core_Features:
     def test_tolist(self):
@@ -1211,7 +1225,7 @@ class Test_README_examples:
         assert x._7 == "Seven"
         assert repr(x) == "CleverDict({7: 'Seven'}, _aliases={'_7': 7}, _vars={})"
         x.add_alias(7, "NumberSeven")
-        assert x._aliases == {7: 7, "_7": 7, "NumberSeven": 7}
+        assert x.__aliases__ == {7: 7, "_7": 7, "NumberSeven": 7}
         x.add_alias(7, "zeven")
         assert (
             repr(x)

--- a/cleverdict/test_cleverdict.py
+++ b/cleverdict/test_cleverdict.py
@@ -1225,7 +1225,7 @@ class Test_README_examples:
         assert x._7 == "Seven"
         assert repr(x) == "CleverDict({7: 'Seven'}, _aliases={'_7': 7}, _vars={})"
         x.add_alias(7, "NumberSeven")
-        assert x.__aliases__ == {7: 7, "_7": 7, "NumberSeven": 7}
+        assert x._aliases == {7: 7, "_7": 7, "NumberSeven": 7}
         x.add_alias(7, "zeven")
         assert (
             repr(x)


### PR DESCRIPTION
- raise RuntimeWarning if a user tries to use '_aliases' as key word and '_aliases' is not a `dict` or an instance of `AliasesDict`
- if `save` or `delete` are used as keywords the will be displayed in `repr` if not explicit ignored